### PR TITLE
Selected electives

### DIFF
--- a/cdegree/client/diagram/events/overlay.events.js
+++ b/cdegree/client/diagram/events/overlay.events.js
@@ -12,7 +12,6 @@ Template.overlayCourse.events({
         profile['selectedElectives'] = newElectives;
         Meteor.users.update({_id:Meteor.user()._id}, {$set: {profile: profile}});
         $('#overlay').fadeOut();
-        //alert("Hello! We are still working on this :-)");
     }
 
 });

--- a/cdegree/client/diagram/events/overlay.events.js
+++ b/cdegree/client/diagram/events/overlay.events.js
@@ -5,8 +5,14 @@ Template.overlayCourse.events({
     },
 
     'click .select-elective': function(event) {
-        //Meteor.user().profile.selectedElectives.push([Session.get("selectedCurse"), event.currentTarget.dataset.id]);
-        alert("Hello! We are still working on this :-)");
+        let electiveType = parseInt(Session.get("selectedCourse"));
+        let profile = Meteor.user().profile;
+        let newElectives = profile.selectedElectives.slice()
+        newElectives.push([electiveType, event.currentTarget.dataset.id]);
+        profile['selectedElectives'] = newElectives;
+        Meteor.users.update({_id:Meteor.user()._id}, {$set: {profile: profile}});
+        $('#overlay').fadeOut();
+        //alert("Hello! We are still working on this :-)");
     }
 
 });

--- a/cdegree/client/diagram/helpers/template-sidebar.helpers.js
+++ b/cdegree/client/diagram/helpers/template-sidebar.helpers.js
@@ -21,8 +21,18 @@ function getRemainingElectiveIds() {
   let electives = Degree.findOne({name: user.degree}).sections.electives.slice();
   let userCompletedElectives = user.completedElectives.slice().map(
       el => el[0]);
+  let userSelectedElectives = user.selectedElectives.map(el => el[0]);
 
   userCompletedElectives.forEach(el => {
+    // guard against student completing more electives than required
+    let idx = electives.indexOf(el);
+
+    if (electives.length > 0 && idx > -1) {
+      electives.splice(idx, 1); // remove completed elective
+    }
+  });
+
+  userSelectedElectives.forEach(el => {
     // guard against student completing more electives than required
     let idx = electives.indexOf(el);
 
@@ -74,6 +84,17 @@ Template.diagramSidebar.helpers({
     electives.forEach(el => {
       let description = Elective.findOne({id: el});
       descriptions.push(description);
+    });
+
+    return descriptions;
+  },
+
+  // returns selected electives
+  selected: function () {
+    let electives = Meteor.user().profile.selectedElectives.map(el => el[1]);
+    let descriptions = [];
+    electives.forEach(el => {
+      descriptions.push(Course.findOne({id:el}));
     });
 
     return descriptions;

--- a/cdegree/client/diagram/templates/template-sidebar.html
+++ b/cdegree/client/diagram/templates/template-sidebar.html
@@ -33,6 +33,14 @@
 
       {{/each }}
 
+      {{#each selected}}
+
+      <div class="classes" data-id="{{id}}">
+        Elective: {{this.id}} - {{this.name}}
+      </div>
+
+      {{/each }}
+
       {{#each electives}}
 
       <div class="classes" data-id="{{id}}">

--- a/cdegree/server/startup/startup.js
+++ b/cdegree/server/startup/startup.js
@@ -63,7 +63,7 @@ Meteor.startup(() => {
     Elective.insert({
         id: 1,
         name: "Upper Division CS Elective",
-        parents: ["IS 4300", "CS 3200", "CS 4120"]
+        parents: ["IS 4300", "CS 3200", "CS 4120", "CS 4550"]
     });
 
     Elective.insert({

--- a/cdegree/server/user/user.config.js
+++ b/cdegree/server/user/user.config.js
@@ -7,6 +7,7 @@ Accounts.onCreateUser(function(options, user) {
                 "ENGW 1111", "MATH 1341"],
             inProgressCourses: ["CS 2800", "MATH 1342", "CS 3800", "CS 3650"],
             completedElectives: [[3, "SOCL 1280"]],
+            selectedElectives: [[1, "IS 4300"]],
             degree: "Bachelor of Science in Computer Science",
             capstone: null,
             fulfilledNUPath: false
@@ -18,6 +19,7 @@ Accounts.onCreateUser(function(options, user) {
             completedReqCourses: [],
                 inProgressCourses: ["CS 1200", "CS 1800", "CS 2500", "CS 2501", "ENGW 1111"],
                 completedElectives: [],
+                selectedElectives: [[2, "BIOL 1111"]],
                 degree: "Bachelor of Science in Computer Science",
                 capstone: null,
                 fulfilledNUPath: false


### PR DESCRIPTION
This PR adds the ability to select an course to fill an elective with from the menu. When you click "choose" the overlay goes away and the elective you clicked in the sidebar earlier is replaced by "Elective: {{new course name}}". It also fixes an oversight where we wanted users to pick web dev as an elective but it was not listed as a course that could satisfy a cs elective, so I added it. It now appears as a choosable course and can be chosen.

I totally understand if we don't want to risk anything, so no pressure at all to evaluate this before class. I'll be up at 8 so I can answer questions in case anyone wants to evaluate it and something isn't right, but I've tested it and I'm happy with it. 

@sebastianruizva please check the diff to make sure nothing reverted. I've also looked it over and every line in the diff is intentional, but I'm not taking any chances.